### PR TITLE
Adding foremen authority to change referral state

### DIFF
--- a/programs/marinade-referral/src/error.rs
+++ b/programs/marinade-referral/src/error.rs
@@ -21,5 +21,9 @@ pub enum ReferralError {
     NotInitializedMintAccount, // 306
 
     #[msg("Referral operation fee was set over the maximum permitted amount")]
-    ReferralOperationFeeOverMax,
+    ReferralOperationFeeOverMax, // 307
+    #[msg("Provided signer account is not permitted to do changes at referral account")]
+    NeitherAdminNorForemanReferralState, // 308
+    #[msg("Provided number of foremen keys exceeded their permitted number")]
+    ExceededNumberForemenSignerKeys, // 309
 }

--- a/programs/marinade-referral/src/instructions/admin.rs
+++ b/programs/marinade-referral/src/instructions/admin.rs
@@ -1,11 +1,15 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, TokenAccount};
 use solana_program::program_pack::IsInitialized;
+use solana_program::system_program;
 
 use crate::constant::*;
-use crate::error::ReferralError::ReferralOperationFeeOverMax;
+use crate::error::ReferralError::{
+    ExceededNumberForemenSignerKeys, NeitherAdminNorForemanReferralState,
+    ReferralOperationFeeOverMax,
+};
 use crate::error::*;
-use crate::states::{GlobalState, ReferralState};
+use crate::states::{GlobalState, ReferralState, MAX_FOREMEN_NUMBER};
 
 //-----------------------------------------------------
 #[derive(Accounts)]
@@ -19,9 +23,10 @@ pub struct Initialize<'info> {
 
     #[account()]
     pub msol_mint_account: CpiAccount<'info, Mint>,
+    // list of foremen accounts are expected to be provided as remaining_accounts of the context
 }
 impl<'info> Initialize<'info> {
-    pub fn process(&mut self) -> ProgramResult {
+    pub fn process(&mut self, foremen_pubkeys: Vec<Pubkey>) -> ProgramResult {
         self.global_state.admin_account = self.admin_account.key();
         self.global_state.msol_mint_account = self.msol_mint_account.key();
 
@@ -29,22 +34,41 @@ impl<'info> Initialize<'info> {
         if !self.msol_mint_account.is_initialized() {
             return Err(ReferralError::NotInitializedMintAccount.into());
         }
+
+        // foremen accounts that are capable to change referral account config
+        set_foremen(foremen_pubkeys, &mut self.global_state)?;
+
         Ok(())
     }
+}
+
+fn set_foremen<'info>(
+    foremen_pubkeys: Vec<Pubkey>,
+    global_state: &mut ProgramAccount<'info, GlobalState>,
+) -> std::result::Result<(), ReferralError> {
+    if foremen_pubkeys.len() > MAX_FOREMEN_NUMBER {
+        return Err(ExceededNumberForemenSignerKeys);
+    }
+    for i in 0..MAX_FOREMEN_NUMBER - 1 {
+        if let Some(foreman_pubkey) = foremen_pubkeys.get(i) {
+            global_state.foremen[i] = *foreman_pubkey;
+        } else {
+            global_state.foremen[i] = system_program::ID;
+        }
+    }
+    Ok(())
 }
 
 //-----------------------------------------------------
 #[derive(Accounts)]
 pub struct InitReferralAccount<'info> {
     // global state
-    #[account(
-        has_one = admin_account,
-    )]
+    #[account()]
     pub global_state: ProgramAccount<'info, GlobalState>,
 
-    // admin account, signer
+    // an admin or a foreman account; account that is permitted to init the referral state
     #[account(signer)]
-    pub admin_account: AccountInfo<'info>,
+    pub admin_or_foreman_account: AccountInfo<'info>,
 
     #[account(zero)] // must be created but empty, ready to be initialized
     pub referral_state: ProgramAccount<'info, ReferralState>,
@@ -61,6 +85,10 @@ pub struct InitReferralAccount<'info> {
 impl<'info> InitReferralAccount<'info> {
     pub fn process(&mut self, partner_name: String) -> ProgramResult {
         msg!("process_init_referral_account");
+
+        // verify whether the signer is permitted to init the referral account
+        check_admin_foreman_permission(&self.admin_or_foreman_account, &self.global_state)?;
+
         if partner_name.len() > 20 {
             msg!("max partner_name.len() is 20");
             return Err(ReferralError::PartnerNameTooLong.into());
@@ -105,6 +133,25 @@ impl<'info> InitReferralAccount<'info> {
 
         Ok(())
     }
+}
+
+fn check_admin_foreman_permission<'info>(
+    account_to_verify: &AccountInfo<'info>,
+    global_state: &ProgramAccount<'info, GlobalState>,
+) -> std::result::Result<(), ReferralError> {
+    let mut permissioned_accounts: Vec<Pubkey> = vec![];
+    permissioned_accounts.push(global_state.admin_account);
+    for i in 0..MAX_FOREMEN_NUMBER - 1 {
+        if global_state.foremen.len() > i && global_state.foremen[i] != Pubkey::default() {
+            permissioned_accounts.push(global_state.foremen[i]);
+        }
+    }
+    for permissioned_account in permissioned_accounts {
+        if permissioned_account.key() == *account_to_verify.key && account_to_verify.is_signer {
+            return Ok(());
+        }
+    }
+    return Err(NeitherAdminNorForemanReferralState);
 }
 
 fn check_partner_accounts<'info>(
@@ -153,18 +200,37 @@ impl<'info> ChangeAuthority<'info> {
     }
 }
 
+//--------------------------------------
+#[derive(Accounts)]
+pub struct ChangeForemen<'info> {
+    // global state
+    #[account()]
+    pub global_state: ProgramAccount<'info, GlobalState>,
+
+    // an admin or a foreman account; accounts with permission to changes
+    #[account(signer)]
+    pub admin_or_foreman_account: AccountInfo<'info>,
+    // the list of new foremen accounts to be configured
+    // are expected to be provided as remaining_accounts of the context
+}
+impl<'info> ChangeForemen<'info> {
+    pub fn process(&mut self, foremen_pubkeys: Vec<Pubkey>) -> ProgramResult {
+        check_admin_foreman_permission(&self.admin_or_foreman_account, &self.global_state)?;
+        set_foremen(foremen_pubkeys, &mut self.global_state)?;
+        Ok(())
+    }
+}
+
 //-----------------------------------------------------
 #[derive(Accounts)]
 pub struct UpdateReferral<'info> {
     // global state
-    #[account(
-        has_one = admin_account,
-    )]
+    #[account()]
     pub global_state: ProgramAccount<'info, GlobalState>,
 
     // admin account
     #[account(signer)]
-    pub admin_account: AccountInfo<'info>,
+    pub admin_or_foreman_account: AccountInfo<'info>,
 
     // referral state
     #[account(mut)]
@@ -187,6 +253,8 @@ impl<'info> UpdateReferral<'info> {
         operation_liquid_unstake_fee: Option<u8>,
         operation_delayed_unstake_fee: Option<u8>,
     ) -> ProgramResult {
+        check_admin_foreman_permission(&self.admin_or_foreman_account, &self.global_state)?;
+
         self.referral_state.pause = pause;
 
         if *self.new_partner_account.key != self.referral_state.partner_account

--- a/programs/marinade-referral/src/instructions/deposit_stake_account.rs
+++ b/programs/marinade-referral/src/instructions/deposit_stake_account.rs
@@ -81,7 +81,7 @@ impl<'info> DepositStakeAccount<'info> {
             &self.token_program,
             &self.mint_to,
             &self.msol_token_partner_account,
-            // Note: self.stake_authority is in reality withdraw_auth (Stake account owner) 
+            // Note: self.stake_authority is in reality withdraw_auth (Stake account owner)
             // we're assuming it's the same owner of the destination mSOL token account
             &self.stake_authority,
         )?;

--- a/programs/marinade-referral/src/lib.rs
+++ b/programs/marinade-referral/src/lib.rs
@@ -40,7 +40,8 @@ pub mod marinade_referral {
     ///Admin
     ///create global state
     pub fn initialize(ctx: Context<Initialize>) -> ProgramResult {
-        ctx.accounts.process()
+        let foremen_pubkeys = get_foremen_pubkeys(ctx.remaining_accounts);
+        ctx.accounts.process(foremen_pubkeys)
     }
 
     ///create referral state
@@ -69,9 +70,15 @@ pub mod marinade_referral {
         )
     }
 
-    /// update partner, authority and beneficiary account based on the new partner
+    /// change admin authority
     pub fn change_authority(ctx: Context<ChangeAuthority>) -> ProgramResult {
         ctx.accounts.process()
+    }
+
+    /// change foremen authorities
+    pub fn change_foremen(ctx: Context<ChangeForemen>) -> ProgramResult {
+        let foremen_pubkeys = get_foremen_pubkeys(ctx.remaining_accounts);
+        ctx.accounts.process(foremen_pubkeys)
     }
 
     // required for https://docs.rs/solana-program-test/1.7.11/solana_program_test/index.html
@@ -85,4 +92,8 @@ pub mod marinade_referral {
             e
         })
     }
+}
+
+fn get_foremen_pubkeys<'info, 'c>(remaining_accounts: &'c [AccountInfo<'info>]) -> Vec<Pubkey> {
+    remaining_accounts.iter().map(|ai| *ai.key).collect()
 }

--- a/programs/marinade-referral/src/states.rs
+++ b/programs/marinade-referral/src/states.rs
@@ -3,6 +3,8 @@ use marinade_finance::{calc::proportional, error::CommonError, Fee};
 
 //-----------------------------------------------------
 ///marinade-referral-program PDA
+pub const MAX_FOREMEN_NUMBER: usize = 2;
+
 #[account]
 pub struct GlobalState {
     // Authority (admin address)
@@ -10,6 +12,9 @@ pub struct GlobalState {
 
     // msol mint account to verify the mint of partner msol account (must be fed externally)
     pub msol_mint_account: Pubkey,
+
+    // cannot use const here: https://github.com/coral-xyz/anchor/issues/335
+    pub foremen: [Pubkey; 2],
 }
 
 //-----------------------------------------------------


### PR DESCRIPTION
This is my proposal for having foremen accounts that make possible to change configuration.

@luciotato : I was thinking in way that having 2 accounts is kind of hardly defined so I coded it with remaining accounts. To be honest, I'm not sure if you are fine with such solution so I'm happy to change it as you say.
What I don't know is if there is a need for new instruction that configures only the fees. The foreman may do changes via `UpdateReferral` instruction. Should that be a new instruction only for fee to be configured here? As the foreman may init the referral account I think it's correct that it could be updated by him as well (i.e., he can change the partner account and partner msol account). If that permission should be left only for admin then I understand a need for the new instruction for changing fees.
Note: I understand that the fee changes should be provided as calls through the TS SDK for ease of use. I haven't started to work on that but when it's clear what are the instructions I will manage it.
...or the fees should be possible to be change by partner account (when signed)?