### PR TITLE
Wrong values of Min/Max keep pct initialize could fail without panic

### DIFF
--- a/programs/marinade-referral/src/error.rs
+++ b/programs/marinade-referral/src/error.rs
@@ -27,6 +27,10 @@ pub enum ReferralError {
     NotAllowedForStakeAsCollateralPartner,
     #[msg("Keep_pct out of valid range")]
     KeepPctOutOfRange,
+    #[msg("Max Keep_pct out of valid range, cannot go over 100%")]
+    MaxKeepPctOutOfRange,
+    #[msg("Min Keep-pct is bounded by value of Max Keep_pct")]
+    MinMaxKeepPctOutOfRange,
     #[msg("Stake-account must be delegated to partner validator")]
     StakeAccountMustBeDelegatedToPartnerValidator,
     #[msg("Stake-account authority must be partner account")]

--- a/programs/marinade-referral/src/instructions/admin.rs
+++ b/programs/marinade-referral/src/instructions/admin.rs
@@ -137,7 +137,7 @@ impl<'info> InitReferralAccount<'info> {
         self.referral_state.operation_liquid_unstake_fee = DEFAULT_OPERATION_FEE_POINTS;
         self.referral_state.operation_delayed_unstake_fee = DEFAULT_OPERATION_FEE_POINTS;
 
-        self.referral_state.accum_deposit_sol_fees = 0;
+        self.referral_state.accum_deposit_sol_fee = 0;
         self.referral_state.accum_deposit_stake_account_fee = 0;
         self.referral_state.accum_liquid_unstake_fee = 0;
         self.referral_state.accum_delayed_unstake_fee = 0;

--- a/programs/marinade-referral/src/instructions/admin.rs
+++ b/programs/marinade-referral/src/instructions/admin.rs
@@ -29,8 +29,13 @@ impl<'info> Initialize<'info> {
         self.global_state.foreman_1 = self.foreman_1.key();
         self.global_state.foreman_2 = self.foreman_2.key();
 
+        if min_keep_pct > max_keep_pct {
+            return Err(MinMaxKeepPctOutOfRange.into());
+        }
         self.global_state.min_keep_pct = min_keep_pct;
-        assert!(max_keep_pct <= 100);
+        if max_keep_pct > 100 {
+            return Err(MaxKeepPctOutOfRange.into());
+        }
         self.global_state.max_keep_pct = max_keep_pct;
 
         // verify if the account that should be considered as MSOL mint is an active mint account

--- a/programs/marinade-referral/src/instructions/deposit_sol.rs
+++ b/programs/marinade-referral/src/instructions/deposit_sol.rs
@@ -77,7 +77,7 @@ impl<'info> Deposit<'info> {
         // update accumulators
         self.referral_state.deposit_sol_amount += lamports;
         self.referral_state.deposit_sol_operations += 1;
-        self.referral_state.accum_deposit_sol_fees += operation_fee;
+        self.referral_state.accum_deposit_sol_fee += operation_fee;
         Ok(())
     }
 

--- a/programs/marinade-referral/src/states.rs
+++ b/programs/marinade-referral/src/states.rs
@@ -77,7 +77,7 @@ pub struct ReferralState {
     pub operation_delayed_unstake_fee: u8,
 
     // accumulators for operation fees paid
-    pub accum_deposit_sol_fees: u64,
+    pub accum_deposit_sol_fee: u64,
     pub accum_deposit_stake_account_fee: u64,
     pub accum_liquid_unstake_fee: u64,
     pub accum_delayed_unstake_fee: u64,
@@ -96,12 +96,7 @@ impl ReferralState {
         self.liq_unstake_sol_amount = 0;
         self.liq_unstake_operations = 0;
 
-        self.accum_deposit_sol_fees = 0;
-        self.accum_deposit_stake_account_fee = 0;
-        self.accum_liquid_unstake_fee = 0;
-        self.accum_delayed_unstake_fee = 0;
-
-        self.accum_deposit_sol_fees = 0;
+        self.accum_deposit_sol_fee = 0;
         self.accum_deposit_stake_account_fee = 0;
         self.accum_liquid_unstake_fee = 0;
         self.accum_delayed_unstake_fee = 0;

--- a/programs/marinade-referral/tests/src/integration_test.rs
+++ b/programs/marinade-referral/tests/src/integration_test.rs
@@ -1323,7 +1323,7 @@ impl MarinadeReferralTestGlobals {
         let referral_state: marinade_referral::states::ReferralState =
             get_account(test, self.partner_referral_state_pubkey).await;
         assert_eq!(referral_state.accum_delayed_unstake_fee, 0);
-        assert_eq!(referral_state.accum_deposit_sol_fees, 0);
+        assert_eq!(referral_state.accum_deposit_sol_fee, 0);
         assert_eq!(referral_state.accum_deposit_stake_account_fee, 0);
         assert_eq!(referral_state.accum_liquid_unstake_fee, 0);
     }

--- a/programs/marinade-referral/tests/src/integration_test/test_admin.rs
+++ b/programs/marinade-referral/tests/src/integration_test/test_admin.rs
@@ -96,7 +96,7 @@ async fn test_init_global_state() -> anyhow::Result<()> {
         "Operation 'delayed unstake fee' should be init value",
     );
     assert_eq!(
-        0, referral_state.accum_deposit_sol_fees,
+        0, referral_state.accum_deposit_sol_fee,
         "Accumulator 'deposit sol fee' should be init at 0",
     );
     assert_eq!(

--- a/programs/marinade-referral/tests/src/integration_test/test_deposit_sol_liquid_unstake.rs
+++ b/programs/marinade-referral/tests/src/integration_test/test_deposit_sol_liquid_unstake.rs
@@ -267,8 +267,8 @@ async fn do_deposit_sol(
         data_before.partner_msol + operation_fee_lamports
     );
     assert_eq!(
-        data_before.referral_state.accum_deposit_sol_fees + operation_fee_lamports,
-        data_after.referral_state.accum_deposit_sol_fees,
+        data_before.referral_state.accum_deposit_sol_fee + operation_fee_lamports,
+        data_after.referral_state.accum_deposit_sol_fee,
         "Deposit sol operation accumulator fee does not increased by exepected amount"
     );
     Ok(())


### PR DESCRIPTION
I think the min/max initialization should check that min is lower than max and the errors could be hinted with an error message not only with a panic.