### PR TITLE
Renaming accumulator names to plural

### DIFF
--- a/programs/marinade-referral/src/instructions/admin.rs
+++ b/programs/marinade-referral/src/instructions/admin.rs
@@ -137,10 +137,10 @@ impl<'info> InitReferralAccount<'info> {
         self.referral_state.operation_liquid_unstake_fee = DEFAULT_OPERATION_FEE_POINTS;
         self.referral_state.operation_delayed_unstake_fee = DEFAULT_OPERATION_FEE_POINTS;
 
-        self.referral_state.accum_deposit_sol_fee = 0;
-        self.referral_state.accum_deposit_stake_account_fee = 0;
-        self.referral_state.accum_liquid_unstake_fee = 0;
-        self.referral_state.accum_delayed_unstake_fee = 0;
+        self.referral_state.accum_deposit_sol_fees = 0;
+        self.referral_state.accum_deposit_stake_account_fees = 0;
+        self.referral_state.accum_liquid_unstake_fees = 0;
+        self.referral_state.accum_delayed_unstake_fees = 0;
 
         Ok(())
     }

--- a/programs/marinade-referral/src/instructions/deposit_sol.rs
+++ b/programs/marinade-referral/src/instructions/deposit_sol.rs
@@ -77,7 +77,7 @@ impl<'info> Deposit<'info> {
         // update accumulators
         self.referral_state.deposit_sol_amount += lamports;
         self.referral_state.deposit_sol_operations += 1;
-        self.referral_state.accum_deposit_sol_fee += operation_fee;
+        self.referral_state.accum_deposit_sol_fees += operation_fee;
         Ok(())
     }
 

--- a/programs/marinade-referral/src/instructions/deposit_stake_account.rs
+++ b/programs/marinade-referral/src/instructions/deposit_stake_account.rs
@@ -101,7 +101,7 @@ impl<'info> DepositStakeAccount<'info> {
         // accumulate
         self.referral_state.deposit_stake_account_amount += delegation.stake;
         self.referral_state.deposit_stake_account_operations += 1;
-        self.referral_state.accum_deposit_stake_account_fee += operation_fee;
+        self.referral_state.accum_deposit_stake_account_fees += operation_fee;
         Ok(())
     }
 

--- a/programs/marinade-referral/src/instructions/liquid_unstake.rs
+++ b/programs/marinade-referral/src/instructions/liquid_unstake.rs
@@ -103,7 +103,7 @@ impl<'info> LiquidUnstake<'info> {
         self.referral_state.liq_unstake_msol_amount += msol_amount_fee_deducted;
         self.referral_state.liq_unstake_sol_amount += user_remove_lamports;
         self.referral_state.liq_unstake_operations += 1;
-        self.referral_state.accum_liquid_unstake_fee += operation_fee;
+        self.referral_state.accum_liquid_unstake_fees += operation_fee;
 
         Ok(())
     }

--- a/programs/marinade-referral/src/states.rs
+++ b/programs/marinade-referral/src/states.rs
@@ -77,10 +77,10 @@ pub struct ReferralState {
     pub operation_delayed_unstake_fee: u8,
 
     // accumulators for operation fees paid
-    pub accum_deposit_sol_fee: u64,
-    pub accum_deposit_stake_account_fee: u64,
-    pub accum_liquid_unstake_fee: u64,
-    pub accum_delayed_unstake_fee: u64,
+    pub accum_deposit_sol_fees: u64,
+    pub accum_deposit_stake_account_fees: u64,
+    pub accum_liquid_unstake_fees: u64,
+    pub accum_delayed_unstake_fees: u64,
 }
 
 impl ReferralState {
@@ -96,10 +96,10 @@ impl ReferralState {
         self.liq_unstake_sol_amount = 0;
         self.liq_unstake_operations = 0;
 
-        self.accum_deposit_sol_fee = 0;
-        self.accum_deposit_stake_account_fee = 0;
-        self.accum_liquid_unstake_fee = 0;
-        self.accum_delayed_unstake_fee = 0;
+        self.accum_deposit_sol_fees = 0;
+        self.accum_deposit_stake_account_fees = 0;
+        self.accum_liquid_unstake_fees = 0;
+        self.accum_delayed_unstake_fees = 0;
     }
 
     pub fn get_liq_unstake_share_amount(&self) -> Result<u64, CommonError> {

--- a/programs/marinade-referral/tests/src/integration_test.rs
+++ b/programs/marinade-referral/tests/src/integration_test.rs
@@ -1322,9 +1322,9 @@ impl MarinadeReferralTestGlobals {
 
         let referral_state: marinade_referral::states::ReferralState =
             get_account(test, self.partner_referral_state_pubkey).await;
-        assert_eq!(referral_state.accum_delayed_unstake_fee, 0);
-        assert_eq!(referral_state.accum_deposit_sol_fee, 0);
-        assert_eq!(referral_state.accum_deposit_stake_account_fee, 0);
-        assert_eq!(referral_state.accum_liquid_unstake_fee, 0);
+        assert_eq!(referral_state.accum_delayed_unstake_fees, 0);
+        assert_eq!(referral_state.accum_deposit_sol_fees, 0);
+        assert_eq!(referral_state.accum_deposit_stake_account_fees, 0);
+        assert_eq!(referral_state.accum_liquid_unstake_fees, 0);
     }
 }

--- a/programs/marinade-referral/tests/src/integration_test/test_admin.rs
+++ b/programs/marinade-referral/tests/src/integration_test/test_admin.rs
@@ -96,19 +96,19 @@ async fn test_init_global_state() -> anyhow::Result<()> {
         "Operation 'delayed unstake fee' should be init value",
     );
     assert_eq!(
-        0, referral_state.accum_deposit_sol_fee,
+        0, referral_state.accum_deposit_sol_fees,
         "Accumulator 'deposit sol fee' should be init at 0",
     );
     assert_eq!(
-        0, referral_state.accum_deposit_stake_account_fee,
+        0, referral_state.accum_deposit_stake_account_fees,
         "Accumulator 'deposit stake account fee' should be init at 0",
     );
     assert_eq!(
-        0, referral_state.accum_liquid_unstake_fee,
+        0, referral_state.accum_liquid_unstake_fees,
         "Accumulator 'liquid unstake fee' should be init at 0",
     );
     assert_eq!(
-        0, referral_state.accum_delayed_unstake_fee,
+        0, referral_state.accum_delayed_unstake_fees,
         "Accumulator 'delayed unstake fee' should be init at 0",
     );
 

--- a/programs/marinade-referral/tests/src/integration_test/test_deposit_sol_liquid_unstake.rs
+++ b/programs/marinade-referral/tests/src/integration_test/test_deposit_sol_liquid_unstake.rs
@@ -267,8 +267,8 @@ async fn do_deposit_sol(
         data_before.partner_msol + operation_fee_lamports
     );
     assert_eq!(
-        data_before.referral_state.accum_deposit_sol_fee + operation_fee_lamports,
-        data_after.referral_state.accum_deposit_sol_fee,
+        data_before.referral_state.accum_deposit_sol_fees + operation_fee_lamports,
+        data_after.referral_state.accum_deposit_sol_fees,
         "Deposit sol operation accumulator fee does not increased by exepected amount"
     );
     Ok(())
@@ -418,8 +418,8 @@ pub async fn do_liquid_unstake(
         "Partner is expected to receive mSOL in the amount of the operation fee"
     );
     assert_eq!(
-        data_before.referral_state.accum_liquid_unstake_fee + operation_fee_lamports,
-        data_after.referral_state.accum_liquid_unstake_fee,
+        data_before.referral_state.accum_liquid_unstake_fees + operation_fee_lamports,
+        data_after.referral_state.accum_liquid_unstake_fees,
         "Liquid unstake operation accumulator fee does not increased by exepected amount"
     );
 

--- a/programs/marinade-referral/tests/src/integration_test/test_deposit_stake_account.rs
+++ b/programs/marinade-referral/tests/src/integration_test/test_deposit_stake_account.rs
@@ -120,7 +120,7 @@ async fn test_deposit_stake_account_with_fees() -> anyhow::Result<()> {
         partner_msol_balance_before + operation_fee_lamports
     );
     assert_eq!(
-        referral_state_after.accum_deposit_stake_account_fee - operation_fee_lamports,
+        referral_state_after.accum_deposit_stake_account_fees - operation_fee_lamports,
         0,
         "Deposit stake account operation accumulator fee does not increased by exepected amount"
     );


### PR DESCRIPTION
Based on the request on plurar names.
The CLI change on this adjustments: https://github.com/marinade-finance/liquid-staking-referral-cli/pull/7

At the comment from @luciotato 
```
the plural was the correct, can you make all plurals?
accum_deposit_sol_fees
accum_deposit_stake_account_fees
accum_liquid_unstake_fees
accum_delayed_unstake_fees
```