### PR TITLE
Adding tests that operation fails when referral account is paused

### DIFF
--- a/programs/marinade-referral/tests/src/integration_test.rs
+++ b/programs/marinade-referral/tests/src/integration_test.rs
@@ -1327,4 +1327,22 @@ impl MarinadeReferralTestGlobals {
         assert_eq!(referral_state.accum_deposit_stake_account_fee, 0);
         assert_eq!(referral_state.accum_liquid_unstake_fee, 0);
     }
+
+    async fn pause_referral_account(&self, test: &mut IntegrationTest) {
+        update_referral_execute(
+            test,
+            self.global_state_pubkey,
+            &self.admin_key,
+            self.partner_referral_state_pubkey,
+            self.partner.keypair.pubkey(),
+            self.msol_partner_token_pubkey,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let referral_state: marinade_referral::states::ReferralState =
+            get_account(test, self.partner_referral_state_pubkey).await;
+        assert_eq!(referral_state.pause, true);
+    }
 }


### PR DESCRIPTION
I found that the operation is not permitted when the `pause` is set to `true`. See
https://github.com/marinade-finance/liquid-staking-referral-program/blob/referral-program-v2/programs/marinade-referral/src/instructions/deposit_sol.rs#L35

So I added at least a test that verify that functionality works. I hope it's beneficial so that's why this PR here.